### PR TITLE
Coredns middleware

### DIFF
--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -1,0 +1,187 @@
+package policy
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coredns/coredns/middleware"
+	"github.com/coredns/coredns/request"
+
+	pb "github.com/infobloxopen/policy-box/pdp-service"
+	"github.com/infobloxopen/policy-box/pep"
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+const (
+	EDNS0_MAP_DATA_TYPE_BYTES = iota
+	EDNS0_MAP_DATA_TYPE_HEX   = iota
+	EDNS0_MAP_DATA_TYPE_IP    = iota
+)
+
+var stringToEDNS0MapType = map[string]uint16{
+	"bytes":   EDNS0_MAP_DATA_TYPE_BYTES,
+	"hex":     EDNS0_MAP_DATA_TYPE_HEX,
+	"address": EDNS0_MAP_DATA_TYPE_IP,
+}
+
+type edns0Map struct {
+	code     uint16
+	name     string
+	dataType uint16
+	destType string
+}
+
+type PolicyMiddleware struct {
+	Endpoint  string
+	Zones     []string
+	EDNS0Map  []edns0Map
+	Timeout   time.Duration
+	Next      middleware.Handler
+	pdp       *pep.Client
+	ErrorFunc func(dns.ResponseWriter, *dns.Msg, int) // failover error handler
+}
+
+func (p *PolicyMiddleware) Connect() error {
+	log.Printf("[DEBUG] Connecting %v", p)
+	p.pdp = pep.NewClient(p.Endpoint)
+	return p.pdp.Connect(p.Timeout)
+}
+
+func (p *PolicyMiddleware) AddEDNS0Map(code, name, dataType, destType string) error {
+	c, err := strconv.ParseUint(code, 0, 16)
+	if err != nil {
+		return fmt.Errorf("Could not parse EDNS0 code: %s", err)
+	}
+	ednsType, ok := stringToEDNS0MapType[dataType]
+	if !ok {
+		return fmt.Errorf("Invalid dataType for EDNS0 map: %s", dataType)
+	}
+	p.EDNS0Map = append(p.EDNS0Map, edns0Map{uint16(c), name, ednsType, destType})
+	return nil
+}
+
+func (p *PolicyMiddleware) getEDNS0Attrs(r *dns.Msg) ([]*pb.Attribute, bool) {
+	foundSourceIP := false
+	var attrs []*pb.Attribute
+
+	o := r.IsEdns0()
+	if o == nil {
+		return nil, false
+	}
+
+	for _, s := range o.Option {
+		switch e := s.(type) {
+		case *dns.EDNS0_NSID:
+			// do stuff with e.Nsid
+		case *dns.EDNS0_SUBNET:
+			// access e.Family, e.Address, etc.
+		case *dns.EDNS0_LOCAL:
+			for _, m := range p.EDNS0Map {
+				if m.code == e.Code {
+					var value string
+					switch m.dataType {
+					case EDNS0_MAP_DATA_TYPE_BYTES:
+						value = string(e.Data)
+					case EDNS0_MAP_DATA_TYPE_HEX:
+						value = hex.EncodeToString(e.Data)
+					case EDNS0_MAP_DATA_TYPE_IP:
+						ip := net.IP(e.Data)
+						value = ip.String()
+					}
+					foundSourceIP = foundSourceIP || (m.name == "source_ip")
+					attrs = append(attrs, &pb.Attribute{Id: m.name, Type: m.destType, Value: value})
+					break
+				}
+			}
+		}
+	}
+	return attrs, foundSourceIP
+}
+
+func (p *PolicyMiddleware) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+
+	// need to process OPT to get customer id
+	var attrs []*pb.Attribute
+	if len(r.Question) > 0 {
+		q := r.Question[0]
+		attrs = append(attrs, &pb.Attribute{Id: "domain_name", Type: "domain", Value: strings.TrimRight(q.Name, ".")})
+		attrs = append(attrs, &pb.Attribute{Id: "dns_qtype", Type: "string", Value: dns.TypeToString[q.Qtype]})
+	}
+
+	edns, foundSourceIP := p.getEDNS0Attrs(r)
+	if len(edns) > 0 {
+		attrs = append(attrs, edns...)
+	}
+
+	if foundSourceIP {
+		attrs = append(attrs, &pb.Attribute{Id: "proxy_source_ip", Type: "address", Value: state.IP()})
+	} else {
+		attrs = append(attrs, &pb.Attribute{Id: "source_ip", Type: "address", Value: state.IP()})
+	}
+
+	var result pb.Response
+	err := p.pdp.Validate(pb.Request{Attributes: attrs}, &result)
+	if err != nil {
+		log.Printf("[ERROR] Policy validation failed due to error %s\n", err)
+		return dns.RcodeServerFailure, err
+	}
+
+	rcode := dns.RcodeRefused
+	switch result.Effect {
+	case pb.Response_PERMIT:
+		rcode, err = p.Next.ServeDNS(ctx, w, r)
+	case pb.Response_DENY:
+		if len(result.Obligation) > 0 {
+			o := result.Obligation[0]
+			if o.Id == "redirect_to" {
+				return p.redirect(o.Value, w, r)
+			} else {
+				log.Printf("[WARNING] Unknown obligation: %v", o)
+			}
+		}
+		if len(result.Obligation) > 1 {
+			log.Printf("[WARNING] Only the first obligation will be enforced: %v", result.Obligation)
+		}
+	}
+
+	return rcode, err
+}
+
+// Name implements the Handler interface
+func (p *PolicyMiddleware) Name() string { return "policy" }
+
+func (p *PolicyMiddleware) redirect(redirect_to string, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+
+	a := new(dns.Msg)
+	a.SetReply(r)
+	a.Compress = true
+	a.Authoritative = true
+
+	var rr dns.RR
+
+	switch state.Family() {
+	case 1:
+		rr = new(dns.A)
+		rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass()}
+		rr.(*dns.A).A = net.ParseIP(redirect_to).To4()
+	case 2:
+		rr = new(dns.AAAA)
+		rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass()}
+		rr.(*dns.AAAA).AAAA = net.ParseIP(redirect_to)
+	}
+
+	a.Answer = []dns.RR{rr}
+
+	state.SizeAndDo(a)
+	w.WriteMsg(a)
+
+	return 0, nil
+}

--- a/contrib/coredns/policy/setup.go
+++ b/contrib/coredns/policy/setup.go
@@ -1,0 +1,106 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/middleware"
+
+	"github.com/mholt/caddy"
+)
+
+const (
+	defaultTimeoutSecs = 5
+)
+
+func init() {
+	caddy.RegisterPlugin("policy", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	mw, err := policyParse(c)
+
+	if err != nil {
+		return middleware.Error("policy", err)
+	}
+
+	c.OnStartup(func() error {
+		err := mw.Connect()
+		if err != nil {
+			return middleware.Error("policy", err)
+		}
+		return nil
+	})
+
+	c.OnShutdown(func() error {
+		return nil
+	})
+
+	dnsserver.GetConfig(c).AddMiddleware(func(next middleware.Handler) middleware.Handler {
+		mw.Next = next
+		return mw
+	})
+
+	return nil
+}
+
+func policyParse(c *caddy.Controller) (*PolicyMiddleware, error) {
+	mw := &PolicyMiddleware{Timeout: time.Duration(defaultTimeoutSecs) * time.Second}
+
+	for c.Next() {
+		if c.Val() == "policy" {
+			c.RemainingArgs()
+			//mw.Zones = c.RemainingArgs()
+			//if len(mw.Zones) == 0 {
+			//	mw.Zones = make([]string, len(c.ServerBlockKeys))
+			//	copy(mw.Zones, c.ServerBlockKeys)
+			//}
+			//middleware.Zones(mw.Zones).Normalize()
+			for c.NextBlock() {
+				switch c.Val() {
+				case "endpoint":
+					args := c.RemainingArgs()
+					if len(args) > 0 {
+						mw.Endpoint = args[0]
+						continue
+					}
+					return nil, c.ArgErr()
+				case "timeout":
+					args := c.RemainingArgs()
+					if len(args) > 0 {
+						d, err := time.ParseDuration(args[0])
+						if err != nil {
+							return nil, fmt.Errorf("Invalid timeout duration'%s': %v. Valid examples are: 5s, 30s, 2m, etc.", args[0], err)
+						}
+						mw.Timeout = d
+						continue
+					}
+					return nil, c.ArgErr()
+				case "edns0":
+					args := c.RemainingArgs()
+					if len(args) < 2 || (len(args) != 4 && len(args) != 2) {
+						return nil, fmt.Errorf("Invalid edns0 directive. Usage: edns0 <code> <name> [ <dataType> <destType> ]. Valid dataTypes are hex (default), bytes, ip. Valid destTypes depend on PDP (default string).")
+					}
+					dataType := "hex"
+					destType := "string"
+					if len(args) == 4 {
+						dataType = args[2]
+						destType = args[3]
+					}
+
+					err := mw.AddEDNS0Map(args[0], args[1], dataType, destType)
+					if err != nil {
+						return nil, fmt.Errorf("Could not add EDNS0 map for %s: %s", args[0], err)
+					}
+				}
+			}
+			return mw, nil
+		}
+	}
+	return nil, errors.New("Policy setup called without keyword 'policy' in Corefile")
+}

--- a/pdpserver/config.go
+++ b/pdpserver/config.go
@@ -4,14 +4,14 @@ import (
 	"flag"
 	"os"
 
-	 log "github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
 type Config struct {
 	Verbose   bool
 	CWD       string
 	Policy    string
-    ServiceEP string
+	ServiceEP string
 	ControlEP string
 }
 

--- a/pdpserver/control.go
+++ b/pdpserver/control.go
@@ -3,9 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"golang.org/x/net/context"
 	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+	"io"
 
 	pb "github.com/infobloxopen/policy-box/pdp-control"
 
@@ -55,7 +55,7 @@ func (s *Server) Upload(stream pb.PDPControl_UploadServer) error {
 
 	log.WithFields(log.Fields{
 		"size": len(data),
-		"id": id}).Info("Data enqueued")
+		"id":   id}).Info("Data enqueued")
 
 	return stream.SendAndClose(controlAck(id))
 }

--- a/pdpserver/queue.go
+++ b/pdpserver/queue.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"math"
-    "sync"
+	"sync"
 
 	"github.com/infobloxopen/policy-box/pdp"
 )
@@ -16,7 +16,7 @@ type Content struct {
 type Queue struct {
 	Lock          *sync.Mutex
 	AutoIncrement int32
-    Items         map[int32]interface{}
+	Items         map[int32]interface{}
 }
 
 func NewQueue() *Queue {

--- a/pdpserver/server.go
+++ b/pdpserver/server.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"google.golang.org/grpc"
 
-	pbs "github.com/infobloxopen/policy-box/pdp-service"
 	pbc "github.com/infobloxopen/policy-box/pdp-control"
+	pbs "github.com/infobloxopen/policy-box/pdp-service"
 
 	"github.com/infobloxopen/policy-box/pdp"
 )
@@ -76,7 +76,7 @@ func (s *Server) ListenControl(addr string) {
 }
 
 func (s *Server) Serve() {
-	go func () {
+	go func() {
 		log.Info("Creating control protocol handler")
 		s.Control.Protocol = grpc.NewServer()
 		pbc.RegisterPDPControlServer(s.Control.Protocol, s)

--- a/pdpserver/service.go
+++ b/pdpserver/service.go
@@ -18,7 +18,7 @@ type AttrMarshaller func(v pdp.AttributeValueType) (string, error)
 type AttrUnmarshaller func(v string) (pdp.AttributeValueType, error)
 
 var (
-	Marshallers map[int]AttrMarshaller = map[int]AttrMarshaller {
+	Marshallers map[int]AttrMarshaller = map[int]AttrMarshaller{
 		pdp.DataTypeUndefined: undefinedMarshaller,
 		pdp.DataTypeBoolean:   booleanMarshaller,
 		pdp.DataTypeString:    stringMarshaller,
@@ -135,8 +135,8 @@ func UnmarshalAttribute(attr *pb.Attribute) (int, pdp.AttributeValueType) {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"value": attr.Value,
-			"type": attr.Type,
-			"id": attr.Id,
+			"type":  attr.Type,
+			"id":    attr.Id,
 			"error": err}).Error("Unmarshaling error")
 
 		return pdp.DataTypeUndefined, pdp.AttributeValueType{}
@@ -178,8 +178,8 @@ func MarshalAttributes(ctx *pdp.Context) []*pb.Attribute {
 			s, err := MarshalAttribute(v)
 			if err != nil {
 				log.WithFields(log.Fields{
-					"type": pdp.DataTypeNames[v.DataType],
-					"id": id,
+					"type":  pdp.DataTypeNames[v.DataType],
+					"id":    id,
 					"error": err}).Error("Marshaling error")
 
 				continue
@@ -233,7 +233,7 @@ func MakeResponse(r pdp.ResponseType, ctx *pdp.Context) *pb.Response {
 
 func (s *Server) Validate(server_ctx context.Context, in *pb.Request) (*pb.Response, error) {
 	ctx := MakeRequestContext(in)
-	log.Info("Validating context")
+	log.Infof("Validating context %v", ctx)
 
 	s.Lock.RLock()
 	p := s.Policy

--- a/pep/client.go
+++ b/pep/client.go
@@ -74,6 +74,9 @@ func (c *Client) Validate(in, out interface{}) error {
 }
 
 func makeRequest(v interface{}) (pb.Request, error) {
+	if req, ok := v.(pb.Request); ok {
+		return req, nil
+	}
 	attrs, err := marshalValue(reflect.ValueOf(v))
 	if err != nil {
 		return pb.Request{}, err


### PR DESCRIPTION
Adds the basic CoreDNS policy middleware.

go fmt some of the code

Allow PEP users to create their own Request and bypass marshaling. This was necessary because the CoreDNS attributes are dynamically defined.