### PR TITLE
Fix PEP response

### DIFF
--- a/contrib/coredns/policy/policy.go
+++ b/contrib/coredns/policy/policy.go
@@ -52,7 +52,7 @@ type PolicyMiddleware struct {
 }
 
 type Response struct {
-	Permit   bool   `pdp:"effect"`
+	Permit   bool   `pdp:"Effect"`
 	Redirect net.IP `pdp:"redirect_to"`
 }
 


### PR DESCRIPTION
The PEP unmarshaller expects the pdp tag for Permit field
to be capitalized.